### PR TITLE
fix: typing annotations for `cv2.Mat`

### DIFF
--- a/src/arcaea_offline_ocr/crop.py
+++ b/src/arcaea_offline_ocr/crop.py
@@ -1,8 +1,7 @@
-from typing import Tuple
-
-from cv2 import Mat
+from typing import Any, Tuple
 
 from .device import Device
+from .types import Mat
 
 __all__ = [
     "crop_img",

--- a/src/arcaea_offline_ocr/mask.py
+++ b/src/arcaea_offline_ocr/mask.py
@@ -1,5 +1,7 @@
-from cv2 import BORDER_CONSTANT, BORDER_ISOLATED, Mat, bitwise_or, dilate, inRange
+from cv2 import BORDER_CONSTANT, BORDER_ISOLATED, bitwise_or, dilate, inRange
 from numpy import array, uint8
+
+from .types import Mat
 
 __all__ = [
     "GRAY_MIN_HSV",

--- a/src/arcaea_offline_ocr/ocr.py
+++ b/src/arcaea_offline_ocr/ocr.py
@@ -5,7 +5,6 @@ from cv2 import (
     CHAIN_APPROX_SIMPLE,
     RETR_EXTERNAL,
     TM_CCOEFF_NORMED,
-    Mat,
     boundingRect,
     findContours,
     imshow,
@@ -25,6 +24,7 @@ from .template import (
     load_builtin_digit_template,
     matchTemplateMultiple,
 )
+from .types import Mat
 
 __all__ = [
     "group_numbers",

--- a/src/arcaea_offline_ocr/recognize.py
+++ b/src/arcaea_offline_ocr/recognize.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 from typing import Callable, Optional
 
-from cv2 import COLOR_BGR2HSV, GaussianBlur, Mat, cvtColor, imread
+from cv2 import COLOR_BGR2HSV, GaussianBlur, cvtColor, imread
 
 from .crop import *
 from .device import Device
 from .mask import *
 from .ocr import *
+from .types import Mat
 from .utils import imread_unicode
 
 __all__ = [

--- a/src/arcaea_offline_ocr/template.py
+++ b/src/arcaea_offline_ocr/template.py
@@ -11,7 +11,6 @@ from cv2 import (
     RETR_EXTERNAL,
     THRESH_BINARY_INV,
     TM_CCOEFF_NORMED,
-    Mat,
     boundingRect,
     cvtColor,
     destroyAllWindows,
@@ -34,6 +33,7 @@ from ._builtin_templates import (
     DEFAULT_REGULAR,
     DEFAULT_REGULAR_ERODED,
 )
+from .types import Mat
 
 __all__ = [
     "TemplateItem",

--- a/src/arcaea_offline_ocr/types.py
+++ b/src/arcaea_offline_ocr/types.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+# from pylance
+Mat = np.ndarray[int, np.dtype[np.generic]]

--- a/src/arcaea_offline_ocr/utils.py
+++ b/src/arcaea_offline_ocr/utils.py
@@ -1,6 +1,8 @@
-from cv2 import IMREAD_UNCHANGED, Mat, imdecode
+from cv2 import IMREAD_UNCHANGED, imdecode
 from numpy import fromfile as np_fromfile
 from numpy import uint8
+
+from .types import Mat
 
 
 def imread_unicode(filepath: str) -> Mat:


### PR DESCRIPTION
close #5